### PR TITLE
fix parsing for nested sections

### DIFF
--- a/mustache/language.rkt
+++ b/mustache/language.rkt
@@ -192,6 +192,7 @@
 ;; Test if `datum' is a mustache sequence (list or vector).
 (define (mustache-seq? datum)
   (and (sequence? datum)
+       (not (hash? datum))
        (not (string? datum))
        (not (bytes? datum))))
 
@@ -200,7 +201,8 @@
   (check-true (mustache-seq? '(1 2 3)))
   (check-true (mustache-seq? #()))
   (check-false (mustache-seq? ""))
-  (check-false (mustache-seq? #"")))
+  (check-false (mustache-seq? #""))
+  (check-false (mustache-seq? (hash 'foo (hash 'bar "abc")))))
 
 ;; Evaluate the given statements when `name' is not bound or is a "falsy" value.
 ;; Mustache stx: {{^foo}}...{{/foo}}

--- a/mustache/parser.rkt
+++ b/mustache/parser.rkt
@@ -160,11 +160,11 @@
                  (current-continuation-marks)
                  name 'eof))
          (values (reverse acc) #f))]
-    [(list (or (section name pos _) (inversion name pos _)) more ...)
+    [(list (or (section n pos _) (inversion n pos _)) more ...)
      (define-values (body succ)
-       (normalize more '() name))
+       (normalize more '() n))
      (define kons (if (section? (first lst)) section inversion))
-     (normalize (or succ '()) (cons (kons name pos body) acc) #f)]
+     (normalize (or succ '()) (cons (kons n pos body) acc) name)]
     [(list (close-tag n pos) more ...)
      (if (equal? n name) 
          (values (reverse acc) more)
@@ -262,6 +262,9 @@
                 (list "foo" "bar"))
   ;; Recognizes sequence closing expressions.
   (check-equal? (^^ (mustache-parse (open-input-string "{{#foo}}{{/foo}}")))
+                (list "foo"))
+  ;; Recognizes nested sequence closing expressions.
+  (check-equal? (^^ (mustache-parse (open-input-string "{{#foo}}{{#bar}}{{bat}{{/bar}}{{/foo}}")))
                 (list "foo"))
   ;; Recognizes escaping expressions.
   (check-equal? (^^ (mustache-parse (open-input-string "{{&foo}}")))

--- a/mustache/tests/nested-sections.ms
+++ b/mustache/tests/nested-sections.ms
@@ -1,0 +1,2 @@
+#lang mustache
+These sections are {{#foo}}{{#bar}}{{bat}}{{/bar}}{{/foo}}.

--- a/mustache/tests/template-test.rkt
+++ b/mustache/tests/template-test.rkt
@@ -5,6 +5,7 @@
          (prefix-in escaping: "escaping.ms")
          (prefix-in section: "section.ms")
          (prefix-in section-ref: "section-ref.ms")
+         (prefix-in nested-sections: "nested-sections.ms")
          (prefix-in inversion: "inversion.ms")
          (prefix-in delimiter: "delimiter.ms")
          (prefix-in partial: "partials.ms"))
@@ -34,11 +35,14 @@
   (check-tpl section:render (hash) "Here are some .\n")
   
   (check-tpl section-ref:render (hash "foo" (list (hash "bar" 42))) "The answer is 42.\n")
+
+  (check-tpl nested-sections:render (hash "foo" (hash "bar" (hash "bat" "nested")))
+                                    "These sections are nested.\n")
   
   (check-tpl inversion:render (hash "foo" "xyz") "\n")
   (check-tpl inversion:render (hash "foo" #f) "Maybe ...\n")
   (check-tpl inversion:render (hash) "Maybe ...\n")
   
   (check-tpl delimiter:render (hash "foo" "bar") "The value is bar.\n")
-  
+
   (check-tpl partial:render (hash) "The content of the partial is I contain only text.\n"))


### PR DESCRIPTION
This fixes the parse error (namely an unmatched closing tag error) when nesting section tags, e.g.

```
{{#post}}
  {{#comments}}
    {{time}}
  {{/comments}}
{{/post}}
```

`mustache-seq?` had to be fixed along the way to return `#f` for hashes so the nested hash input will work.
