### PR TITLE
Partial env bug fixes

### DIFF
--- a/mustache/language.rkt
+++ b/mustache/language.rkt
@@ -109,7 +109,10 @@
          (box (dict:ref frame key))))
      (if (box? value)
          (unbox value)
-         (failure)))])
+         (failure)))
+   (define (dict-has-key? dict key)
+     (for/or ([frame (environment-frames dict)])
+       (dict:has-key? frame key)))])
 
 (define empty-environment (environment '()))
 
@@ -140,7 +143,8 @@
 
 (module+ test
   (check-equal? (with-env 'a (env-ref 'a)) "")
-  (check-equal? (with-env (hash 'a 'b) (env-ref 'a)) 'b))
+  (check-equal? (with-env (hash 'a 'b) (env-ref 'a)) 'b)
+  (check-equal? (with-env (hash) (with-env (current-env) (env-ref 'a))) ""))
 
 ;; Evaluate the body if `name' is bound in the current environment.
 ;; If the value bound to `name' is a list, the body will be evaluated
@@ -233,5 +237,5 @@
         (check-equal? (get-output-string (current-output-port))
                       expected))))
   (check-partial "tests/only-text.ms" "I contain only text.\n")
-  (check-partial "tests/simple-ref.ms" "The variable value is bar.\n" (hash "foo" "bar")))
-   
+  (check-partial "tests/simple-ref.ms" "The variable value is bar.\n" (hash "foo" "bar"))
+  (check-partial "tests/simple-ref.ms" "The variable value is .\n" (hash)))

--- a/mustache/tests/partial-in-section.ms
+++ b/mustache/tests/partial-in-section.ms
@@ -1,0 +1,2 @@
+#lang mustache
+Partial: {{#sect}}{{>simple-ref.ms}}{{/sect}}

--- a/mustache/tests/template-test.rkt
+++ b/mustache/tests/template-test.rkt
@@ -8,7 +8,8 @@
          (prefix-in nested-sections: "nested-sections.ms")
          (prefix-in inversion: "inversion.ms")
          (prefix-in delimiter: "delimiter.ms")
-         (prefix-in partial: "partials.ms"))
+         (prefix-in partial: "partials.ms")
+         (prefix-in partial-in-section: "partial-in-section.ms"))
 
 (module+ test
   (require rackunit))
@@ -45,4 +46,11 @@
   
   (check-tpl delimiter:render (hash "foo" "bar") "The value is bar.\n")
 
-  (check-tpl partial:render (hash) "The content of the partial is I contain only text.\n"))
+  (check-tpl partial:render (hash) "The content of the partial is I contain only text.\n")
+
+  (check-tpl partial-in-section:render (hash) "Partial: ")
+  (check-tpl partial-in-section:render (hash "sect" #t) "Partial: The variable value is .\n")
+  (check-tpl partial-in-section:render (hash "sect" (hash)  "foo" "bar")
+                                       "Partial: The variable value is bar.\n")
+  (check-tpl partial-in-section:render (hash "sect" (hash "foo" "bar"))
+                                       "Partial: The variable value is bar.\n"))


### PR DESCRIPTION
Currently `partial` passes `(current-env)` to `render` resulting in a new `struct:environment` with the old env in its `frames` field. This can cause errors inside `dict-ref` for the environment when it tries to call `dict:has-key?` on the wrapped environment, e.g. this happens when the partial references a name not in the original dict.

This fix adds `dict-has-key?` to `struct:environment` so that the nested environments work without erring.

I tried just passing the old env through on partials instead but it causes issues because in the context of the partial the env from the parent template is technically a different struct type.
