### PR TITLE
Support for dotted names and a single dot for the current env context.

### DIFF
--- a/mustache/tests/dotted-names.ms
+++ b/mustache/tests/dotted-names.ms
@@ -1,0 +1,2 @@
+#lang mustache
+Dotted: {{#a}}{{b.c}}{{/a}}.

--- a/mustache/tests/template-test.rkt
+++ b/mustache/tests/template-test.rkt
@@ -9,7 +9,8 @@
          (prefix-in inversion: "inversion.ms")
          (prefix-in delimiter: "delimiter.ms")
          (prefix-in partial: "partials.ms")
-         (prefix-in partial-in-section: "partial-in-section.ms"))
+         (prefix-in partial-in-section: "partial-in-section.ms")
+         (prefix-in dotted-names: "dotted-names.ms"))
 
 (module+ test
   (require racket/stream)
@@ -56,4 +57,9 @@
   (check-tpl partial-in-section:render (hash "sect" (hash)  "foo" "bar")
                                        "Partial: The variable value is bar.\n")
   (check-tpl partial-in-section:render (hash "sect" (hash "foo" "bar"))
-                                       "Partial: The variable value is bar.\n"))
+                                       "Partial: The variable value is bar.\n")
+
+  (check-tpl dotted-names:render (hash "a" (hash "b" (hash "c" "yes")) "b" (hash "c" "ERROR"))
+                                 "Dotted: yes.\n")
+  (check-tpl dotted-names:render (hash "a" (hash "b" '()) "b" (hash "c" "ERROR"))
+                                 "Dotted: .\n"))


### PR DESCRIPTION
This pull request adds support for dotted names (e.g. `{{foo.bar}}`) and a single dot (`{{.}}`) for the current env context. The latter requires knowing the current context even if it's not a dict so `struct:environment` and `with-env` are updated to push non-dicts onto the stack and then just ignore them during non-dot lookups.

[The relevant mustache spec](https://github.com/mustache/spec/blob/master/specs/interpolation.yml#L124).
